### PR TITLE
Fixed stretched crop preview.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+*.iml
+.gradle
+/local.properties
+/.idea
+/.idea/caches
+/.idea/libraries
+/.idea/modules.xml
+/.idea/workspace.xml
+/.idea/navEditor.xml
+/.idea/assetWizardSettings.xml
+.DS_Store
+/build
+/captures
+.externalNativeBuild
+.cxx
+local.properties

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ImageCropView is a Jetpack Compose library that provides a simple and customizab
 It supports various cropping styles such as free-form, square, and circular cropping, making it easy to integrate image cropping functionality into your Compose UI.
 
 
-https://github.com/rroohit/ImageCropView/assets/36406595/d856d353-ab62-42c5-83db-ea99f8b4e8d8
+https://github.com/rroohit/ImageCropView/assets/36406595/92906b61-277a-4bd6-a814-e3573ae36ee3
 
 
 ## Setup

--- a/app/src/main/java/com/k/image/cropview/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/k/image/cropview/ui/main/MainViewModel.kt
@@ -34,8 +34,7 @@ class MainViewModel : ViewModel() {
 
     companion object {
         const val IMAGE_URL =
-            "https://images.unsplash.com/photo-1572782252655-9c8771392601?q=80&w=2112&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
-        //"https://images.unsplash.com/photo-1698417386582-5e7a652254f5?q=80&w=2859&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+            "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTqYclGdTITnebvplFZ86xIQBY4tsCkYowwaQ&s"
     }
 
 

--- a/app/src/main/java/com/k/image/cropview/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/k/image/cropview/ui/main/MainViewModel.kt
@@ -34,7 +34,10 @@ class MainViewModel : ViewModel() {
 
     companion object {
         const val IMAGE_URL =
-            "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTqYclGdTITnebvplFZ86xIQBY4tsCkYowwaQ&s"
+//            "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTqYclGdTITnebvplFZ86xIQBY4tsCkYowwaQ&s"
+//        "https://d3nx71g9uvfl9m.cloudfront.net/image_db/f79e1140-acc3-11ec-be3c-0242c0a84003.png"
+//        "https://e0.pxfuel.com/wallpapers/351/703/desktop-wallpaper-fluid-abstract-space-atmosphere-world-planets-space.jpg"
+        "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ_IjTvDCsLIL9dsnw832sBkIG3DpkxMg-XFQ&s"
     }
 
 

--- a/cropview/src/main/java/com/image/cropview/ImageCropView.kt
+++ b/cropview/src/main/java/com/image/cropview/ImageCropView.kt
@@ -70,7 +70,7 @@ public class ImageCrop(
             modifier = modifier
                 .fillMaxSize()
                 .onSizeChanged { intSize ->
-                    cropUtil.onCanvasSizeChanged(intSize = intSize)
+                    cropUtil.onCanvasSizeChanged(intSize)
                 }
                 .pointerInput(Unit) {
                     detectDragGestures(
@@ -91,10 +91,36 @@ public class ImageCrop(
                 },
 
             onDraw = {
+                // Canvas size
+                val canvasWidth = size.width
+                val canvasHeight = size.height
+
+                // Bitmap dimensions
+                val imageWidth = bitmapImage.width.toFloat()
+                val imageHeight = bitmapImage.height.toFloat()
+
+                // Aspect ratios
+                val imageAspectRatio = imageWidth / imageHeight
+                val canvasAspectRatio = canvasWidth / canvasHeight
+
+                // Determine the scaling factors
+                val scaledWidth: Float
+                val scaledHeight: Float
+
+                if (imageAspectRatio > canvasAspectRatio) {
+                    // Fit by width
+                    scaledWidth = canvasWidth
+                    scaledHeight = canvasWidth / imageAspectRatio
+                } else {
+                    // Fit by height
+                    scaledWidth = canvasHeight * imageAspectRatio
+                    scaledHeight = canvasHeight
+                }
+
                 // Draw bitmap image on rect
                 drawBitmap(
                     bitmap = bitmapImage,
-                    canvasSize = cropUtil.canvasSize
+                    canvasSize = CanvasSize(scaledWidth, scaledHeight),
                 )
 
                 // Circle
@@ -113,7 +139,7 @@ public class ImageCrop(
                     }
 
                     clipPath(circlePath, clipOp = ClipOp.Difference) {
-                        drawRect(SolidColor(Color.Black.copy(alpha = 0.5f)))
+                        drawRect(SolidColor(Color.Black.copy(alpha = 0.2f)))
                     }
                 }
 

--- a/cropview/src/main/java/com/image/cropview/ImageCropView.kt
+++ b/cropview/src/main/java/com/image/cropview/ImageCropView.kt
@@ -1,6 +1,8 @@
 package com.image.cropview
 
 import android.graphics.Bitmap
+import android.graphics.Paint
+import android.graphics.RectF
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,11 +13,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.graphics.ClipOp
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.*
 import androidx.compose.ui.graphics.drawscope.clipPath
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.Dp
@@ -106,22 +106,33 @@ public class ImageCrop(
                 // Determine the scaling factors
                 val scaledWidth: Float
                 val scaledHeight: Float
+                val dx: Float
+                val dy: Float
 
                 if (imageAspectRatio > canvasAspectRatio) {
                     // Fit by width
                     scaledWidth = canvasWidth
                     scaledHeight = canvasWidth / imageAspectRatio
+                    dx = 0f
+                    dy = (canvasHeight - scaledHeight) / 2f
                 } else {
                     // Fit by height
                     scaledWidth = canvasHeight * imageAspectRatio
                     scaledHeight = canvasHeight
+                    dx = (canvasWidth - scaledWidth) / 2f
+                    dy = 0f
                 }
 
                 // Draw bitmap image on rect
-                drawBitmap(
-                    bitmap = bitmapImage,
-                    canvasSize = CanvasSize(scaledWidth, scaledHeight),
-                )
+                drawIntoCanvas { canvas ->
+                    val paint = Paint()
+                    canvas.nativeCanvas.drawBitmap(
+                        bitmapImage,
+                        null,
+                        RectF(dx, dy, dx + scaledWidth, dy + scaledHeight),
+                        paint
+                    )
+                }
 
                 // Circle
                 if (cropType == CropType.PROFILE_CIRCLE) {

--- a/local.properties
+++ b/local.properties
@@ -5,4 +5,4 @@
 # For customization when using a Version Control System, please read the
 # header note.
 #Thu Oct 12 09:37:25 IST 2023
-sdk.dir=/Users/rohitchavan/Library/Android/sdk
+sdk.dir=C\:\\Users\\works\\AppData\\Local\\Android\\Sdk

--- a/local.properties
+++ b/local.properties
@@ -5,4 +5,4 @@
 # For customization when using a Version Control System, please read the
 # header note.
 #Thu Oct 12 09:37:25 IST 2023
-sdk.dir=C\:\\Users\\works\\AppData\\Local\\Android\\Sdk
+sdk.dir=/Users/rohitchavan/Library/Android/sdk


### PR DESCRIPTION
The crop preview bitmap was stretching to cover the entire Canvas, and that broke the aspect-ratio of the bitmap. as images who were shorter or thinner than the Canvas were appearing stretched.  I have fixed exactly that.

before
![Screenshot_2024-07-25_211503_1_optimized](https://github.com/user-attachments/assets/acc437eb-d7eb-4ef4-a8fe-8562b017d83a)

after
![Screenshot_2024-07-25_141518_optimized](https://github.com/user-attachments/assets/983bcf63-5dc5-4ed2-9153-6a5dce792bb0)
