### PR TITLE
fix: Handle IllegalArgumentException for width and height (closes #6)

### DIFF
--- a/app/src/main/java/com/k/image/cropview/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/k/image/cropview/ui/main/MainActivity.kt
@@ -53,7 +53,6 @@ import com.image.cropview.ImageCrop
 import com.k.image.cropview.R
 import com.k.image.cropview.ui.components.ImageItem
 import com.k.image.cropview.ui.components.ItemIcon
-import com.k.image.cropview.ui.theme.Chatelle2
 import com.k.image.cropview.ui.theme.ImageCropViewTheme
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -131,13 +130,13 @@ class MainActivity : ComponentActivity() {
                                 imageCrop = ImageCrop(bitmapImage = bm)
                                 imageCrop.ImageCropView(
                                     modifier = Modifier.fillMaxSize(),
-                                    guideLineColor = Chatelle2,
-                                    guideLineWidth = 1.5.dp,
-                                    edgeCircleSize = 3.dp,
+                                    guideLineColor = Color.LightGray,
+                                    guideLineWidth = 2.dp,
+                                    edgeCircleSize = 5.dp,
                                     showGuideLines = viewModel.cropType.collectAsState().value != CropType.PROFILE_CIRCLE,
                                     // showGuideLines = true,
                                     cropType = viewModel.cropType.collectAsState().value,
-                                    edgeType = EdgeType.SQUARE
+                                    edgeType = EdgeType.CIRCULAR
                                 )
 
                                 showProgressBarState.value = false

--- a/cropview/src/main/java/com/image/cropview/CanvasSize.kt
+++ b/cropview/src/main/java/com/image/cropview/CanvasSize.kt
@@ -3,10 +3,10 @@ package com.image.cropview
 /**
  *  - Data class representing the size of a canvas in a crop view.
  *
- *  @property canvasWidth The width of the canvas.
- *  @property canvasHeight The height of the canvas.
+ *  @property width The width of the canvas.
+ *  @property height The height of the canvas.
  */
 public data class CanvasSize(
-    val canvasWidth: Float = 0.0f,
-    val canvasHeight: Float = 0.0f
+    val width: Float = 0.0f,
+    val height: Float = 0.0f
 )

--- a/cropview/src/main/java/com/image/cropview/CropUtil.kt
+++ b/cropview/src/main/java/com/image/cropview/CropUtil.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantConstructorKeyword")
+
 package com.image.cropview
 
 import android.graphics.Bitmap
@@ -114,8 +116,8 @@ public class CropUtil constructor(private var mBitmapImage: Bitmap) {
      */
     public fun resetCropIRect() {
         // Irect resetting
-        val canWidth = canvasSize.canvasWidth
-        val canHeight = canvasSize.canvasHeight
+        val canWidth = canvasSize.width
+        val canHeight = canvasSize.height
 
         if (getCurrCropType() == CropType.SQUARE ||
             getCurrCropType() == CropType.PROFILE_CIRCLE
@@ -251,26 +253,26 @@ public class CropUtil constructor(private var mBitmapImage: Bitmap) {
                 val y = offsetCheck.y
                 var newOffset: Offset? = null
 
-                if (y <= 0F && x > 0.0F && (x + iRect.size.width in 0F..canvasSize.canvasWidth)) {
+                if (y <= 0F && x > 0.0F && (x + iRect.size.width in 0F..canvasSize.width)) {
                     // top side touched to edge
                     newOffset = Offset(x, 0.0F)
 
-                } else if (x <= 0F && y > 0F && (y + iRect.size.height in 0F..canvasSize.canvasHeight)) {
+                } else if (x <= 0F && y > 0F && (y + iRect.size.height in 0F..canvasSize.height)) {
                     // left side touched to edge
                     newOffset = Offset(0.0F, y)
 
-                } else if ((x + iRect.size.width >= canvasSize.canvasWidth) && y >= 0F
-                    && (y + iRect.size.height in 0F..canvasSize.canvasHeight)
+                } else if ((x + iRect.size.width >= canvasSize.width) && y >= 0F
+                    && (y + iRect.size.height in 0F..canvasSize.height)
                 ) {
                     // right side touched to edge
-                    newOffset = Offset((canvasSize.canvasWidth - iRect.size.width), y)
+                    newOffset = Offset((canvasSize.width - iRect.size.width), y)
 
-                } else if ((y + iRect.size.height >= canvasSize.canvasHeight) &&
+                } else if ((y + iRect.size.height >= canvasSize.height) &&
                     x > 0F &&
-                    (x + iRect.size.width in 0F..canvasSize.canvasWidth)
+                    (x + iRect.size.width in 0F..canvasSize.width)
                 ) {
                     // bottom side touched to edge
-                    newOffset = Offset(x, (canvasSize.canvasHeight - iRect.size.height))
+                    newOffset = Offset(x, (canvasSize.height - iRect.size.height))
                 }
                 if (newOffset != null) {
                     updateIRectTopLeftPoint(newOffset)
@@ -440,19 +442,19 @@ public class CropUtil constructor(private var mBitmapImage: Bitmap) {
      */
     private fun bottomLeftCornerDrag(dragPoint: Offset) {
         dragDiffCalculation(dragPoint)?.let { dragDiff ->
-            val canvasHeight = canvasSize.canvasHeight
+            val canvasHeight = canvasSize.height
             val size = iRect.size
 
             // For Y-Axis
             val h = (size.height + dragDiff.y)
-            val height = if ((h + iRect.topLeft.y) > (canvasSize.canvasHeight)) {
-                (canvasSize.canvasHeight - iRect.topLeft.y)
+            val height = if ((h + iRect.topLeft.y) > (canvasSize.height)) {
+                (canvasSize.height - iRect.topLeft.y)
             } else h
 
 
             // For X-Axis
-            val x = if ((iRect.topLeft.x + dragDiff.x) >= (canvasSize.canvasWidth - minLimit)) {
-                canvasSize.canvasWidth - minLimit
+            val x = if ((iRect.topLeft.x + dragDiff.x) >= (canvasSize.width - minLimit)) {
+                canvasSize.width - minLimit
             } else {
                 val a = iRect.topLeft.x + dragDiff.x
                 if (a < 0F) return
@@ -467,7 +469,7 @@ public class CropUtil constructor(private var mBitmapImage: Bitmap) {
                 (size.width + abs(dragDiff.x))
             } else (size.width - abs(dragDiff.x))
 
-            if (width >= canvasSize.canvasWidth) width = canvasSize.canvasWidth
+            if (width >= canvasSize.width) width = canvasSize.width
 
             val sizeOfIRect = when (cropType) {
                 CropType.PROFILE_CIRCLE, CropType.SQUARE -> {
@@ -508,13 +510,13 @@ public class CropUtil constructor(private var mBitmapImage: Bitmap) {
      */
     private fun bottomRightCornerDrag(dragPoint: Offset) {
         dragDiffCalculation(dragPoint)?.let { dragDiff ->
-            val canvasHeight = canvasSize.canvasHeight
+            val canvasHeight = canvasSize.height
             val (sizeWidth, sizeHeight) = iRect.size
 
             val newWidth = (sizeWidth + dragDiff.x)
-                .coerceAtMost(canvasSize.canvasWidth - iRect.topLeft.x)
+                .coerceAtMost(canvasSize.width - iRect.topLeft.x)
             val newHeight = (sizeHeight + dragDiff.y)
-                .coerceAtMost(canvasSize.canvasHeight - iRect.topLeft.y)
+                .coerceAtMost(canvasSize.height - iRect.topLeft.y)
 
             val sizeOfIrect = when (cropType) {
                 CropType.PROFILE_CIRCLE, CropType.SQUARE -> {
@@ -581,7 +583,7 @@ public class CropUtil constructor(private var mBitmapImage: Bitmap) {
     private fun isDragPointInsideTheCanvas(dragPoint: Offset): Boolean {
         val x = (dragPoint.x + iRect.size.width)
         val y = (dragPoint.y + iRect.size.height)
-        return (x in 0F..canvasSize.canvasWidth && y in 0F..canvasSize.canvasHeight)
+        return (x in 0F..canvasSize.width && y in 0F..canvasSize.height)
     }
 
     /**
@@ -694,37 +696,37 @@ public class CropUtil constructor(private var mBitmapImage: Bitmap) {
      *  @return The cropped [Bitmap] based on the current rectangle bounds.
      */
     public fun cropImage(): Bitmap {
-        val canvasWidth = canvasSize.canvasWidth.toInt()
-        val canvasHeight = canvasSize.canvasHeight.toInt()
+        val canvasWidth = canvasSize.width.toInt()
+        val canvasHeight = canvasSize.height.toInt()
 
         // Get the rectangle bounds to crop
-        val rect = getRectFromPoints()
+        val cropRect = getRectFromPoints()
+
+        val sourceBitmap = bitmapImage ?: mBitmapImage
+
+        if (canvasWidth <= 0 || canvasHeight <= 0) return sourceBitmap
 
         // Create a scaled bitmap from the original image
-        val bitmap: Bitmap = bitmapImage?.let {
-            Bitmap.createScaledBitmap(it, canvasWidth, canvasHeight, true)
-        } ?: Bitmap.createScaledBitmap(mBitmapImage, canvasWidth, canvasHeight, true)
+        val scaledBitmap = Bitmap.createScaledBitmap(sourceBitmap, canvasWidth, canvasHeight, true)
 
-        // Calculate the cropped region bounds within the scaled bitmap.
-        var imgLef = if (rect.left.toInt() < 0) 0 else rect.left.toInt()
-        var imgTop = if (rect.top.toInt() < 0) 0 else rect.top.toInt()
+        var cropLeft = cropRect.left.toInt().coerceAtLeast(0)
+        var cropTop = cropRect.top.toInt().coerceAtLeast(0)
+        val cropWidth = cropRect.width.toInt().coerceAtMost(canvasWidth)
+        val cropHeight = cropRect.height.toInt().coerceAtMost(canvasHeight)
 
-        val imgWidth = if (rect.width.toInt() > canvasWidth) canvasWidth else rect.width.toInt()
-        val imgHeight =
-            if (rect.height.toInt() > canvasHeight) canvasHeight else rect.height.toInt()
 
         // Adjust bounds to ensure they fit within the canvas size.
-        if (imgLef + imgWidth > canvasWidth) {
-            imgLef = 0
+        if (cropLeft + cropWidth > canvasWidth) {
+            cropLeft = 0
         }
-        if (imgTop + imgHeight > canvasHeight) {
-            imgTop = abs(canvasHeight - imgHeight)
+        if (cropTop + cropHeight > canvasHeight) {
+            cropTop = abs(canvasHeight - cropHeight)
         }
 
         // Create the cropped bitmap.
-        val cropBitmap = if (imgWidth <= 0 || imgHeight <= 0) {
+        val cropBitmap = if (cropWidth <= 0 || cropHeight <= 0) {
             Bitmap.createBitmap(
-                bitmap,
+                scaledBitmap,
                 0,
                 0,
                 canvasWidth,
@@ -732,11 +734,11 @@ public class CropUtil constructor(private var mBitmapImage: Bitmap) {
             )
         } else {
             Bitmap.createBitmap(
-                bitmap,
-                imgLef,
-                imgTop,
-                imgWidth,
-                imgHeight
+                scaledBitmap,
+                cropLeft,
+                cropTop,
+                cropWidth,
+                cropHeight
             )
         }
 

--- a/cropview/src/main/java/com/image/cropview/DrawScopeExtensions.kt
+++ b/cropview/src/main/java/com/image/cropview/DrawScopeExtensions.kt
@@ -15,8 +15,8 @@ import kotlin.math.abs
 public fun DrawScope.drawBitmap(bitmap: Bitmap, canvasSize: CanvasSize) {
     val mBitmap = Bitmap.createScaledBitmap(
         bitmap,
-        canvasSize.canvasWidth.toInt(),
-        canvasSize.canvasHeight.toInt(),
+        canvasSize.width.toInt(),
+        canvasSize.height.toInt(),
         false
     )
     drawImage(mBitmap.asImageBitmap())

--- a/cropview/src/main/java/com/image/cropview/ImageCropView.kt
+++ b/cropview/src/main/java/com/image/cropview/ImageCropView.kt
@@ -3,7 +3,6 @@ package com.image.cropview
 import android.graphics.Bitmap
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.detectDragGestures
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -68,7 +67,6 @@ public class ImageCrop(
 
         Canvas(
             modifier = modifier
-                .fillMaxSize()
                 .onSizeChanged { intSize ->
                     cropUtil.onCanvasSizeChanged(intSize = intSize)
                 }


### PR DESCRIPTION
Refactor: Update CropUtil and CanvasSize for improved image cropping

- Updated cropImage function logic in CropUtil to properly crop the image.
- Modified `drawBitmap` function to correctly handle the canvas size for drawing the bitmap.
- Modified the ImageCropView to adjust the size.
- Updated the logic to check if the rectangle fits within the canvas.
- Updated some function naming and fixed minor code issues.