### PR TITLE
Add ability to crop the source image instead of the scaled image

### DIFF
--- a/cropview/src/main/java/com/image/cropview/ImageCropView.kt
+++ b/cropview/src/main/java/com/image/cropview/ImageCropView.kt
@@ -153,12 +153,17 @@ public class ImageCrop(
 
     /**
      * Implements the [OnCrop] interface method to perform cropping and return the resulting [Bitmap].
+     * @param cropSourceImage [Boolean] If true, crop the source image, if false, crop the scaled image in the canvas
      *
      * @return The cropped [Bitmap] based on the current crop view configuration.
      */
-    override fun onCrop(): Bitmap {
+    override fun onCrop(cropSourceImage: Boolean): Bitmap {
         this.cropU.updateBitmapImage(bitmapImage)
-        return this.cropU.cropImage()
+        return if (cropSourceImage) {
+            this.cropU.cropSourceImage()
+        } else {
+            this.cropU.cropImage()
+        }
     }
 
     /**
@@ -176,10 +181,11 @@ public class ImageCrop(
 private interface OnCrop {
     /**
      * Performs cropping and returns the resulting [Bitmap].
+     * @param cropSourceImage [Boolean] If true, crop the source image, if false, crop the scaled image in the canvas
      *
      * @return The cropped [Bitmap] based on the current crop view configuration.
      */
-    fun onCrop(): Bitmap
+    fun onCrop(cropSourceImage: Boolean = false): Bitmap
 
     /**
      * Resets the crop view to its initial state.


### PR DESCRIPTION
https://github.com/rroohit/ImageCropView/issues/14

I want to be able to crop using the dimensions of the cropper, but scaled to the source file's dimensions so that the full source file's size is maintained after cropping.

This adds a param to `onCrop` to  allow this behavior to `cropSourceImage`, defaulting to false to maintain the existing behavior.

I didn't change the sample app since it's not super easy to see this behavior visually without showing image dimensions.